### PR TITLE
Revert "Looks like zip-zip isn't necessary anymore"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     ipa (0.2.0)
       CFPropertyList (~> 2.3)
       rubyzip (~> 1.1)
+      zip-zip (~> 0.3)
 
 GEM
   remote: https://rubygems.org/
@@ -11,6 +12,8 @@ GEM
     CFPropertyList (2.3.1)
     rake (10.4.2)
     rubyzip (1.1.7)
+    zip-zip (0.3)
+      rubyzip (>= 1.0.0)
 
 PLATFORMS
   ruby

--- a/ipa.gemspec
+++ b/ipa.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project         = 'ipa'
 
   s.add_dependency 'rubyzip', '~> 1.1'
+  s.add_dependency 'zip-zip', '~> 0.3'
   s.add_dependency 'CFPropertyList', '~> 2.3'
   s.add_development_dependency 'bundler', '~> 1'
 


### PR DESCRIPTION
This reverts commit 29b36f66283d7893c6bb6391dd7d9ea118e62153.
The dependency still seems to be necessary. Otherwise I cannot instantiate the class. Can you have a look, thanks!
